### PR TITLE
Potential fix for code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -36,6 +36,11 @@ export const createUser = asyncHandler(async (req, res, next) => {
     req.body.isEmailVerified = true;
   }
 
+  // Check for valid email type to prevent NoSQL injection
+  if (typeof email !== 'string') {
+    return next(new ErrorResponse('Invalid email type', 400, 'INVALID_EMAIL'));
+  }
+
   // Check for duplicate email
   const existingUser = await User.findOne({ email });
   if (existingUser) {


### PR DESCRIPTION
Potential fix for [https://github.com/aioutlet/user-service/security/code-scanning/2](https://github.com/aioutlet/user-service/security/code-scanning/2)

To fix the problem, where user-controlled data is embedded directly in a MongoDB query object, you need to ensure that the data cannot be interpreted as a query operator or special value by MongoDB. The best way is to either use the `$eq` operator (forcing the value to be treated as a literal, no matter its type), or to explicitly check that the value is a string before building the query. Since email addresses should always be strings, the most robust and explicit fix is to enforce a type check. Insert a check before the query, and reject requests where `email` is not a string.  

The required change is in `src/controllers/user.controller.js`, at and above line 40.  
- Add a validation before running `User.findOne({ email })` that checks that `email` is a string.
- If `email` is not a string, return a 400 error response.

**Required changes:**
- Insert a type check on `email` after line 33 (after validation).
- If not a string, call `next(new ErrorResponse(...))` to return an error.
- No external library or import changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
